### PR TITLE
enterprise-binary-overrides: adding enterprise override capabilities …

### DIFF
--- a/operations/provision-nomad/dev/vagrant-local/README.md
+++ b/operations/provision-nomad/dev/vagrant-local/README.md
@@ -32,7 +32,15 @@ The Vagrant Development Nomad guide is for **educational purposes only**. It's d
 
 We will now provision the development Nomad cluster in Vagrant.
 
-### Step 1: Start Vagrant
+### Step 1 (OPTIONAL): Copy over enterprise binaries
+
+If you want to override the OSS binaries with Enterprise ones, you can copy a Linux version of the enterprise binaries into the enterprise-binaries directory.   You are responsible for downloading and verifying validity of these binaries.   
+
+DO NOT CHECK BINARIES INTO GIT!!!!
+DO NOT CHECK BINARIES INTO GIT!!!!
+DO NOT CHECK BINARIES INTO GIT!!!!
+
+### Step 2: Start Vagrant
 
 Run `vagrant up` to start the VM and configure Nomad. That's it! Once provisioned, view the Vagrant ouput for next steps.
 

--- a/operations/provision-nomad/dev/vagrant-local/Vagrantfile
+++ b/operations/provision-nomad/dev/vagrant-local/Vagrantfile
@@ -10,7 +10,7 @@ base_box = ENV['BASE_BOX'] || "bento/ubuntu-16.04"
 # Consul variables
 consul_install = ["true", "1"].include?((ENV['CONSUL_INSTALL'] || true).to_s.downcase)
 consul_host_port = ENV['CONSUL_HOST_PORT'] || 8500
-consul_version = ENV['CONSUL_VERSION'] || "1.2.3"
+consul_version = ENV['CONSUL_VERSION'] || "1.4.0"
 consul_ent_url = ENV['CONSUL_ENT_URL']
 consul_group = "consul"
 consul_user = "consul"
@@ -20,7 +20,7 @@ consul_home = "/srv/consul"
 # Vault variables
 vault_install = ["true", "1"].include?((ENV['VAULT_INSTALL'] || true).to_s.downcase)
 vault_host_port = ENV['VAULT_HOST_PORT'] || 8200
-vault_version = ENV['VAULT_VERSION'] || "0.11.3"
+vault_version = ENV['VAULT_VERSION'] || "0.11.4"
 vault_ent_url = ENV['VAULT_ENT_URL']
 vault_group = "vault"
 vault_user = "vault"
@@ -63,6 +63,8 @@ Vagrant.configure("2") do |config|
   config.vm.box = base_box
   config.vm.hostname = "nomad"
 
+  # Map the enterprise binaries folder to allow overrides of individual OSS binaries with enterprise ones
+  config.vm.synced_folder "enterprise-binaries/", "/var/tmp/enterprise-binaries"
   # Bootstrap the vm
   config.vm.provision "shell", inline: "curl https://raw.githubusercontent.com/hashicorp/guides-configuration/master/shared/scripts/base.sh | bash"
 
@@ -87,6 +89,8 @@ Vagrant.configure("2") do |config|
         "USER" => consul_user,
         "GROUP" => consul_group,
       }
+
+    config.vm.provision "shell", inline: "[[ -f /var/tmp/enterprise-binaries/consul ]] && cp /var/tmp/enterprise-binaries/consul /usr/local/bin"
 
     config.vm.provision "shell", inline: "curl https://raw.githubusercontent.com/hashicorp/guides-configuration/master/consul/scripts/install-consul-systemd.sh | bash"
   end
@@ -113,6 +117,8 @@ Vagrant.configure("2") do |config|
         "GROUP" => vault_group,
       }
 
+    config.vm.provision "shell", inline: "[[ -f /var/tmp/enterprise-binaries/vault ]] && cp /var/tmp/enterprise-binaries/vault /usr/local/bin"
+
     config.vm.provision "shell", inline: "curl https://raw.githubusercontent.com/hashicorp/guides-configuration/master/vault/scripts/install-vault-systemd.sh | bash"
   end
 
@@ -127,6 +133,8 @@ Vagrant.configure("2") do |config|
       "USER" => nomad_user,
       "GROUP" => nomad_group,
     }
+
+  config.vm.provision "shell", inline: "[[ -f /var/tmp/enterprise-binaries/nomad ]] && cp /var/tmp/enterprise-binaries/nomad /usr/local/bin"
 
   config.vm.provision "shell", inline: "curl https://raw.githubusercontent.com/hashicorp/guides-configuration/master/nomad/scripts/install-nomad-systemd.sh | bash"
   config.vm.provision "shell", inline: $nomad_setup, privileged: false

--- a/operations/provision-nomad/dev/vagrant-local/enterprise-binaries/README.md
+++ b/operations/provision-nomad/dev/vagrant-local/enterprise-binaries/README.md
@@ -1,0 +1,3 @@
+# Enterprise binaries
+
+Place any Vault, Consul or Nomad binaries into this directory to override the OSS binaries downloaded by default.  Ensure permissions are 0755 (though they probably should be anyway).   You will be responsible for any license updates necessary to keep these binaries running.


### PR DESCRIPTION
Stub directory and copy instructions to allow for an easier upgrade to enterprise locally.   Intent is that SEs or other Hashicorporeals can easily run local Vagrant enterprise environments.   