### PR TITLE
stop all jobs with script

### DIFF
--- a/operations/multi-job-demo/README.md
+++ b/operations/multi-job-demo/README.md
@@ -325,9 +325,6 @@ Note that the QA team could do either of the following if it wanted to use more 
 1. Ask a Nomad administrator to temporarily increase the qa quota.
 
 ## Cleanup
-Before destroying your resources with Terraform, you **must stop** all Nomad jobs in all namespaces. (You can do this in the Nomad UI by selecting the jobs and then clicking the "Stop" button and then the "Yes, Stop" button to confirm.) Failure to do this will cause the `terraform destroy` command to fail and leave your AWS infrastructure only partially destroyed.  If you do forget this step, the way to recover is to find your subnet in the AWS console, then navigate to its route table, and then add the internet gateway with destination "0.0.0.0/0".  When adding the route, selecting "Internet Gateway" for the target should show the right one that was previously associated with your subnet. After saving the new route, you should be able to stop the Nomad jobs and then re-run `terraform destroy`.
-
-
 If you are using Terraform OSS, please do the following:
 1. Run `export TF_WARN_OUTPUT_ERRORS=1` to suppress errors related to outputs for the nomadconsul module during the destroy.
 1. Run `terraform destroy` to destroy the provisioned infrastructure.

--- a/operations/multi-job-demo/aws/modules/network/outputs.tf
+++ b/operations/multi-job-demo/aws/modules/network/outputs.tf
@@ -7,3 +7,7 @@ output "vpc_id" {
 output "subnet_id" {
   value = "${aws_subnet.public_subnet.id}"
 }
+
+output "route_table_association_id" {
+  value = "${aws_route_table_association.public_subnet.id}"
+}

--- a/operations/multi-job-demo/aws/modules/nomadconsul/nomadconsul.tf
+++ b/operations/multi-job-demo/aws/modules/nomadconsul/nomadconsul.tf
@@ -263,6 +263,9 @@ resource "aws_instance" "primary" {
     owner = "${var.owner}"
     TTL = "${var.ttl}"
     created-by = "Terraform"
+    # We add this tag to make the Nomad server dependent on the route_table_association
+    # So that the latter won't be destroyed before the Nomad server
+    route_table_association_id = "${var.route_table_association_id}"
   }
 
   user_data            = "${data.template_file.user_data_server_primary.rendered}"
@@ -298,7 +301,8 @@ resource "aws_instance" "client" {
   vpc_security_group_ids = ["${aws_security_group.primary.id}"]
   subnet_id              = "${var.subnet_id}"
   count                  = "${var.client_count}"
-  depends_on             = ["aws_instance.primary"]
+
+  #depends_on             = ["aws_instance.primary"]
 
   #Instance tags
   tags {
@@ -312,7 +316,7 @@ resource "aws_instance" "client" {
   user_data = "${data.template_file.user_data_client.rendered}"
   iam_instance_profile = "${aws_iam_instance_profile.instance_profile.name}"
 
-  depends_on = ["data.null_data_source.get_bootstrap_token"]
+  depends_on = ["data.external.get_bootstrap_token"]
 }
 
 # IAM Instance Profile

--- a/operations/multi-job-demo/aws/modules/nomadconsul/variables.tf
+++ b/operations/multi-job-demo/aws/modules/nomadconsul/variables.tf
@@ -12,3 +12,4 @@ variable "ttl" {}
 variable "vpc_id" {}
 variable "subnet_id" {}
 variable "private_key_data" {}
+variable "route_table_association_id" {}

--- a/operations/multi-job-demo/aws/stop_all_jobs.sh
+++ b/operations/multi-job-demo/aws/stop_all_jobs.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+stop_jobs_in_namespace () {
+   namespace=$1
+   job_status=$(nomad job status -token=$nomad_token -address=$address -namespace=$namespace -short)
+   if [ "$job_status" != "No running jobs" ]; then
+     running_jobs=$(nomad job status -token=$nomad_token -address=$address -namespace=$namespace -short | sed 1,1d | cut -d ' ' -f 1)
+     echo "namespace is $namespace"
+     echo $running_jobs
+     for job in $running_jobs; do
+       echo "will stop job $job"
+       nomad job stop -token=$nomad_token -address=$address -namespace=$namespace $job
+     done
+   fi
+}
+
+nomad_token=${bootstrap_token}
+address=${address}
+stop_jobs_in_namespace default
+stop_jobs_in_namespace dev
+stop_jobs_in_namespace qa


### PR DESCRIPTION
I added a script to stop all Nomad jobs so that the user does not need to remember to do this themself.  This was needed because otherwise, `terraform destroy` would give errors and they would be unable to remove all the AWS infrastructure provided.

Another issue was that the aws_route_table_association was being destroyed before the EC2 instance and  making it impossible for the Nomad provider to clean up the things it had created.  I fixed this by making the EC2 instance for the Nomad server depend on the aws_route_table_association.  This required me to modify my network module to return it as an output and for my nomadconsul module that creates the EC2 instances to consume it with a variable so I could attach it to the Nomad server EC2 instance as a tag. 

I've tested that my stop_all_jobs.sh script does work both when I did not run any Nomad jobs at all and when I did run them, both with the bootstrap token and with the dev and qa tokens.