### PR TITLE
fixed sock shop demo variables.tf

### DIFF
--- a/application-deployment/microservices/aws/variables.tf
+++ b/application-deployment/microservices/aws/variables.tf
@@ -5,7 +5,7 @@ variable "region" {
 
 variable "ami" {
   description = "AMI ID"
-  default = "ami-0773061edb0eb6550"
+  default = "ami-009feb0e09775afc6"
 }
 
 variable "vpc_cidr" {


### PR DESCRIPTION
I had updated README.md for the Sock Shop microservices demo a long time again to give a new AMI ID and also had updated terraform.tfvars.example, but had not updated variables.tf.