### PR TITLE
add some Sentinel policies

### DIFF
--- a/operations/sentinel/README.md
+++ b/operations/sentinel/README.md
@@ -1,4 +1,4 @@
-# Nomad + Sentinel 
+# Nomad + Sentinel
 The goal of this guide is to help users learn how to enable and write Sentinel policies for Nomad.
 
 ## Estimated Time to Complete
@@ -128,7 +128,7 @@ allowed_docker_images = rule {
 	}
 }
 ```
-If job job's image name does not match the 'allowed_images' regex then the job submission will fail. 
+If job job's image name does not match the 'allowed_images' regex then the job submission will fail.
 
 Now apply the sentinel policy:
 ```bash
@@ -411,3 +411,14 @@ $ nomad inspect example
     }
 }
 ```
+
+### Some Additional Sentinel Policies
+Several years after this guide was written, Roger Berlind added the following Sentinel policies:
+  * [allow-docker-and-java-drivers.sentinel](./sentinel_policies/allow-docker-and-java-drivers.sentinel)
+  * [prevent-docker-host-network.sentinel](./sentinel_policies/prevent-docker-host-network.sentinel)
+  * [restrict-docker-images-and-prevent-latest-tag.sentinel](./sentinel_policies/restrict-docker-images-and-prevent-latest-tag.sentinel)
+  * [bind-namespaces-to-clients.sentinel](./sentinel_policies/bind-namespaces-to-clients.sentinel)
+
+Variants of the first three of these were already in the [multi-job-demo](../multi-job-demo) section of this repository.
+
+The fourth was brand-new and can be used to restrict Nomad jobs to specific Nomad clients using a `meta` tag called "namespace" on some or all Nomad clients. See the comment at the top of the policy for an example client configuration stanza.

--- a/operations/sentinel/sentinel_policies/allow-docker-and-java-drivers.sentinel
+++ b/operations/sentinel/sentinel_policies/allow-docker-and-java-drivers.sentinel
@@ -1,0 +1,15 @@
+# Only allow the Docker and Java drivers
+
+# Allow Docker and Java rule
+allow_docker_and_java = rule {
+  all job.task_groups as tg {
+    all tg.tasks as task {
+      task.driver in ["docker", "java"]
+    }
+  }
+}
+
+# Main rule
+main = rule {
+  allow_docker_and_java
+}

--- a/operations/sentinel/sentinel_policies/bind-namespaces-to-clients.sentinel
+++ b/operations/sentinel/sentinel_policies/bind-namespaces-to-clients.sentinel
@@ -1,0 +1,46 @@
+# Force deployment of jobs to clients with namespace meta tag equal to the
+# namespace specified by the job
+
+# Each Nomad client should have a client stanza like this:
+# client {
+#   enabled = true
+#   meta {
+#     namespace = "<namespace"
+#   }
+# }
+# where namespace is set to some namespace, <namespace>
+
+# The policy ensures that every job has a suitable constraint.
+# The constraint then ensures that jobs can only be deployed to suitable clients.
+
+# validate_namespace_isolation function
+validate_namespace_isolation = func() {
+  validated = false
+
+  # Check constraints until we find one with attribute (l_target) set to
+  # ${meta.namespace}. Then verify that the constraint's value (r_target) is
+  # set to the job's namespace.
+  for job.constraints as c {
+    if c.l_target is "${meta.namespace}" and c.r_target is job.namespace {
+      validated = true
+      break
+    }
+  }
+
+  # Print violation message if a suitable constraint was not found
+  if not validated {
+    print("You tried to run a job in the", job.namespace, "namespace.")
+    print("Each job must include a constraint with attribute set to",
+          "${meta.namespace} and value set to the namespace of the job.")
+  }
+
+  return validated
+}
+
+# Call the validate_namespace_isolation function
+validated = validate_namespace_isolation()
+
+# Main rule
+main = rule {
+  validated
+}

--- a/operations/sentinel/sentinel_policies/prevent-docker-host-network.sentinel
+++ b/operations/sentinel/sentinel_policies/prevent-docker-host-network.sentinel
@@ -1,0 +1,15 @@
+# Prevent Docker containers from running with host network mode
+
+# prevent_host_network rule
+prevent_host_network = rule {
+  all job.task_groups as tg {
+    all tg.tasks as task {
+      (task.config.network_mode is not "host") else true
+    }
+  }
+}
+
+# Main rule
+main = rule {
+  prevent_host_network
+}

--- a/operations/sentinel/sentinel_policies/restrict-docker-images-and-prevent-latest-tag.sentinel
+++ b/operations/sentinel/sentinel_policies/restrict-docker-images-and-prevent-latest-tag.sentinel
@@ -1,0 +1,26 @@
+# This policy restricts which Docker images are allowed and also prevents use of
+# the "latest" tag since the image must specify a tag that starts with a number.
+
+# Allowed Docker images
+allowed_images = [
+  "nginx",
+  "mongo",
+]
+
+# Restrict allowed Docker images
+restrict_images = rule {
+  all job.task_groups as tg {
+    all tg.tasks as task {
+      any allowed_images as allowed {
+        # Note that we require ":" and a tag after it
+        # which must start with a number, preventing "latest"
+        task.config.image matches allowed + ":[0-9](.*)"
+      }
+    }
+  }
+}
+
+# Main rule
+main = rule {
+  restrict_images
+}


### PR DESCRIPTION
This PR adds modified version of 3 Sentinel policies used in the multijob-demo directly to the operations/sentinel directory.
It also adds a brand new policy, bind-namespaces-to-clients.sentinel, that can be used to tie namespaces to specific Nomad clients.